### PR TITLE
feat: add dedicated SQLite writer pools

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -24,6 +24,7 @@ pub struct AppState {
     pub cfg: Cfg,
     pub shard_senders: Vec<mpsc::Sender<ShardWriteOperation>>,
     pub db_pools: Vec<SqlitePool>,
+    pub write_db_pools: Vec<SqlitePool>,
     /// Cache for inflight write operations to prevent race conditions in async mode.
     /// When async_write=true, SET operations return OK immediately but the actual
     /// database write happens asynchronously. This cache stores the key-value pairs
@@ -71,45 +72,21 @@ impl AppState {
             cfg.sqlite_auto_upgrade_legacy_auto_vacuum_concurrency();
 
         let mut db_pools_futures = vec![];
+        let mut write_db_pools_futures = vec![];
         let pool_max_connections = cfg.sqlite_pool_max_connections();
+        let write_pool_max_connections = cfg.sqlite_write_pool_max_connections();
         for i in 0..cfg.num_shards {
-            let data_dir = cfg.data_dir.clone();
-            let db_path = format!("{}/shard_{}.db", data_dir, i);
-
-            // Get SQLite configuration with defaults
-            let cache_size_mb = cfg.sqlite_cache_size_per_connection_mb();
-            let busy_timeout_ms = cfg.sqlite_busy_timeout_ms();
-            let synchronous = cfg.sqlite_synchronous();
-            let mmap_size = cfg.sqlite_mmap_per_connection_bytes();
-
-            let mut connect_options =
-                SqliteConnectOptions::from_str(&format!("sqlite:{}", db_path))
-                    .expect(&format!(
-                        "Failed to parse connection string for shard {}",
-                        i
-                    ))
-                    .create_if_missing(true)
-                    .journal_mode(SqliteJournalMode::Wal)
-                    .busy_timeout(std::time::Duration::from_millis(busy_timeout_ms));
-
-            // Configure SQLite PRAGMAs for optimal server performance
-            connect_options = connect_options
-                .pragma("auto_vacuum", "INCREMENTAL")
-                .pragma("synchronous", synchronous.as_str())
-                .pragma("cache_size", format!("-{}", cache_size_mb * 1024)) // Negative means KiB
-                .pragma("temp_store", "MEMORY")
-                .pragma("foreign_keys", "true");
-
-            // Enable memory-mapped I/O if configured
-            if mmap_size > 0 {
-                connect_options = connect_options.pragma("mmap_size", mmap_size.to_string());
-            }
-
             db_pools_futures.push(
                 SqlitePoolOptions::new()
                     .max_connections(pool_max_connections)
-                    .connect_with(connect_options),
-            )
+                    .connect_with(build_sqlite_connect_options(&cfg, i)),
+            );
+
+            write_db_pools_futures.push(
+                SqlitePoolOptions::new()
+                    .max_connections(write_pool_max_connections)
+                    .connect_with(build_sqlite_connect_options(&cfg, i)),
+            );
         }
 
         let db_pool_results: Vec<Result<SqlitePool, sqlx::Error>> =
@@ -119,6 +96,20 @@ impl AppState {
             .enumerate()
             .map(|(i, res)| {
                 res.unwrap_or_else(|e| panic!("Failed to connect to shard {} DB: {}", i, e))
+            })
+            .collect();
+        let write_db_pool_results: Vec<Result<SqlitePool, sqlx::Error>> =
+            join_all(write_db_pools_futures).await;
+        let write_db_pools: Vec<SqlitePool> = write_db_pool_results
+            .into_iter()
+            .enumerate()
+            .map(|(i, res)| {
+                res.unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to connect to shard {} dedicated writer DB: {}",
+                        i, e
+                    )
+                })
             })
             .collect();
 
@@ -204,6 +195,7 @@ impl AppState {
             cfg,
             shard_senders: shard_senders_vec,
             db_pools,
+            write_db_pools,
             inflight_cache,
             inflight_hcache,
             cluster_manager,
@@ -222,6 +214,35 @@ impl AppState {
     pub fn namespaced_key(&self, namespace: &str, key: &str) -> String {
         format!("{}:{}", namespace, key)
     }
+}
+
+fn build_sqlite_connect_options(cfg: &Cfg, shard_id: usize) -> SqliteConnectOptions {
+    let db_path = format!("{}/shard_{}.db", cfg.data_dir, shard_id);
+
+    // Get SQLite configuration with defaults
+    let cache_size_mb = cfg.sqlite_cache_size_per_connection_mb();
+    let busy_timeout_ms = cfg.sqlite_busy_timeout_ms();
+    let synchronous = cfg.sqlite_synchronous();
+    let mmap_size = cfg.sqlite_mmap_per_connection_bytes();
+
+    let mut connect_options = SqliteConnectOptions::from_str(&format!("sqlite:{}", db_path))
+        .unwrap_or_else(|_| panic!("Failed to parse connection string for shard {}", shard_id))
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(std::time::Duration::from_millis(busy_timeout_ms));
+
+    connect_options = connect_options
+        .pragma("auto_vacuum", "INCREMENTAL")
+        .pragma("synchronous", synchronous.as_str())
+        .pragma("cache_size", format!("-{}", cache_size_mb * 1024))
+        .pragma("temp_store", "MEMORY")
+        .pragma("foreign_keys", "true");
+
+    if mmap_size > 0 {
+        connect_options = connect_options.pragma("mmap_size", mmap_size.to_string());
+    }
+
+    connect_options
 }
 
 const SQLITE_AUTO_VACUUM_NONE: i64 = 0;

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,6 +184,7 @@ impl Cfg {
         let mmap_per_shard_mb = cfg.sqlite_mmap_per_shard_mb();
         let mmap_per_connection_mb = cfg.sqlite_mmap_per_connection_mb();
         let pool_max_connections = cfg.sqlite_pool_max_connections();
+        let write_pool_max_connections = cfg.sqlite_write_pool_max_connections();
         let auto_upgrade_legacy_auto_vacuum = cfg.sqlite_auto_upgrade_legacy_auto_vacuum();
         let auto_upgrade_legacy_auto_vacuum_concurrency =
             cfg.sqlite_auto_upgrade_legacy_auto_vacuum_concurrency();
@@ -203,7 +204,10 @@ impl Cfg {
         } else {
             println!("  mmap_size: disabled");
         }
-        println!("  pool_max_connections: {}", pool_max_connections);
+        println!(
+            "  pool_max_connections: {} read + {} dedicated writer",
+            pool_max_connections, write_pool_max_connections
+        );
         println!(
             "  auto_upgrade_legacy_auto_vacuum: {}",
             auto_upgrade_legacy_auto_vacuum
@@ -258,7 +262,7 @@ impl Cfg {
         }
 
         let shards = self.num_shards.max(1) as i64;
-        let connections = self.sqlite_pool_max_connections().max(1) as i64;
+        let connections = self.sqlite_total_pool_connections_per_shard().max(1) as i64;
         let divisor = shards.saturating_mul(connections);
 
         let per_connection = (total as i64) / divisor;
@@ -307,7 +311,7 @@ impl Cfg {
         }
 
         let shards = self.num_shards.max(1) as u64;
-        let connections = self.sqlite_pool_max_connections().max(1) as u64;
+        let connections = self.sqlite_total_pool_connections_per_shard().max(1) as u64;
         let divisor = shards.saturating_mul(connections);
 
         if divisor == 0 {
@@ -340,6 +344,18 @@ impl Cfg {
             0 => 1,
             value => value,
         }
+    }
+
+    /// Dedicated writer pool size per shard.
+    pub fn sqlite_write_pool_max_connections(&self) -> u32 {
+        1
+    }
+
+    /// Total SQLite connections per shard across read and dedicated writer pools.
+    pub fn sqlite_total_pool_connections_per_shard(&self) -> u32 {
+        self.sqlite_pool_max_connections()
+            .saturating_add(self.sqlite_write_pool_max_connections())
+            .max(1)
     }
 
     /// Whether startup auto-upgrades legacy shard DBs to INCREMENTAL auto_vacuum.

--- a/src/main.rs
+++ b/src/main.rs
@@ -812,7 +812,7 @@ async fn run_server(config_path: &str) -> Result<()> {
 
     // Spawn shard writer tasks using the receivers populated by AppState::new
     for (i, receiver) in shard_receivers.into_iter().enumerate() {
-        let pool = shared_state.db_pools[i].clone();
+        let pool = shared_state.write_db_pools[i].clone();
         let batch_size = cfg.batch_size.unwrap_or(1);
         let batch_timeout_ms = cfg.batch_timeout_ms.unwrap_or(0);
         let inflight_cache = shared_state.inflight_cache.clone();

--- a/src/redis/protocol.rs
+++ b/src/redis/protocol.rs
@@ -1005,20 +1005,24 @@ mod tests {
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("EX requires a value"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("EX requires a value")
+        );
 
         // Test SET with PX but no value
         let input = b"*4\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$5\r\nvalue\r\n$2\r\nPX\r\n";
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("PX requires a value"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("PX requires a value")
+        );
     }
 
     #[test]
@@ -1027,10 +1031,12 @@ mod tests {
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown SET option: XX"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unknown SET option: XX")
+        );
     }
 
     #[test]
@@ -1039,10 +1045,12 @@ mod tests {
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid seconds value"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid seconds value")
+        );
     }
 
     #[test]
@@ -1052,20 +1060,24 @@ mod tests {
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("TTL requires exactly 1 argument"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("TTL requires exactly 1 argument")
+        );
 
         // Too few arguments
         let input = b"*1\r\n$3\r\nTTL\r\n";
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("TTL requires exactly 1 argument"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("TTL requires exactly 1 argument")
+        );
     }
 
     #[test]
@@ -1075,20 +1087,24 @@ mod tests {
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("EXPIRE requires exactly 2 arguments"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("EXPIRE requires exactly 2 arguments")
+        );
 
         // Too few arguments
         let input = b"*2\r\n$6\r\nEXPIRE\r\n$5\r\nmykey\r\n";
         let (resp, _) = parse_resp_with_remaining(input).unwrap();
         let result = parse_command(resp);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("EXPIRE requires exactly 2 arguments"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("EXPIRE requires exactly 2 arguments")
+        );
     }
 
     #[test]
@@ -1516,10 +1532,12 @@ mod tests {
             "HEXPIRE", "myhash", "abc", "FIELDS", "1", "field1",
         ]));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid seconds value"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid seconds value")
+        );
     }
 
     #[test]
@@ -1529,10 +1547,12 @@ mod tests {
             "HEXPIRE", "myhash", "10", "NX", "FIELDS", "0",
         ]));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("at least one field"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at least one field")
+        );
     }
 
     #[test]
@@ -1598,10 +1618,12 @@ mod tests {
             "field1",
         ]));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid timestamp value"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid timestamp value")
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -521,7 +521,7 @@ async fn handle_del_multiple(
         }
 
         let shard_index = state.get_shard(&key);
-        let pool = &state.db_pools[shard_index];
+        let pool = &state.write_db_pools[shard_index];
 
         // Check if key exists first
         let exists = sqlx::query("SELECT 1 FROM blobs WHERE key = ?")
@@ -870,7 +870,7 @@ async fn handle_hset(
     }
 
     let shard_index = state.get_shard(&key);
-    let pool = &state.db_pools[shard_index];
+    let pool = &state.write_db_pools[shard_index];
     let table_name = format!("blobs_{}", namespace);
 
     let table_exists = match hash_table_exists(pool, &table_name).await {
@@ -1028,7 +1028,7 @@ async fn handle_hsetex(
 
         let shard_index = state.get_shard(&field_key);
         let sender = &state.shard_senders[shard_index];
-        let pool = &state.db_pools[shard_index];
+        let pool = &state.write_db_pools[shard_index];
         let table_name = format!("blobs_{}", namespace);
 
         let table_exists = match hash_table_exists(pool, &table_name).await {
@@ -1201,7 +1201,7 @@ async fn handle_hdel(
     }
 
     let shard_index = state.get_shard(&key);
-    let pool = &state.db_pools[shard_index];
+    let pool = &state.write_db_pools[shard_index];
     let table_name = format!("blobs_{}", namespace);
 
     // First check if key exists
@@ -1984,10 +1984,12 @@ async fn handle_blobasaur_vacuum(
 mod tests {
     use super::*;
     use crate::cluster::ClusterManager;
-    use crate::{config::Cfg, shard_manager};
+    use crate::config::{Cfg, SqliteConfig};
+    use crate::shard_manager::{self, ShardWriteOperation};
     use futures::future::BoxFuture;
     use tempfile::TempDir;
     use tokio::net::{TcpListener, TcpStream};
+    use tokio::time::{Duration, timeout};
 
     struct TestContext {
         state: Arc<AppState>,
@@ -2015,14 +2017,19 @@ mod tests {
                 sqlite: None,
             };
 
-            let mut receivers = Vec::new();
-            let state = Arc::new(AppState::new(cfg.clone(), &mut receivers).await.unwrap());
+            Self::from_cfg(temp_dir, cfg).await
+        }
 
+        async fn from_cfg(temp_dir: TempDir, cfg: Cfg) -> Self {
             let batch_size = cfg.batch_size.unwrap_or(1);
             let batch_timeout = cfg.batch_timeout_ms.unwrap_or(0);
+
+            let mut receivers = Vec::new();
+            let state = Arc::new(AppState::new(cfg, &mut receivers).await.unwrap());
+
             let mut writer_handles = Vec::new();
             for (i, receiver) in receivers.into_iter().enumerate() {
-                let pool = state.db_pools[i].clone();
+                let pool = state.write_db_pools[i].clone();
                 let inflight_cache = state.inflight_cache.clone();
                 let inflight_hcache = state.inflight_hcache.clone();
                 let metrics = state.metrics.clone();
@@ -2055,6 +2062,29 @@ mod tests {
             for handle in writer_handles {
                 let _ = handle.await;
             }
+        }
+    }
+
+    fn single_read_connection_cfg(temp_dir: &TempDir, async_write: bool) -> Cfg {
+        Cfg {
+            data_dir: temp_dir.path().to_string_lossy().into_owned(),
+            num_shards: 1,
+            storage_compression: None,
+            async_write: Some(async_write),
+            batch_size: Some(1),
+            batch_timeout_ms: Some(0),
+            addr: None,
+            cluster: None,
+            metrics: None,
+            sqlite: Some(SqliteConfig {
+                cache_size_mb: None,
+                busy_timeout_ms: Some(250),
+                synchronous: None,
+                mmap_size: None,
+                max_connections: Some(1),
+                auto_upgrade_legacy_auto_vacuum: None,
+                auto_upgrade_legacy_auto_vacuum_concurrency: None,
+            }),
         }
     }
 
@@ -2422,6 +2452,229 @@ mod tests {
         })
         .await;
         assert_null(frame);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn sync_write_completes_while_read_pool_connection_is_occupied() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let cfg = single_read_connection_cfg(&temp_dir, false);
+        let ctx = TestContext::from_cfg(temp_dir, cfg).await;
+
+        let read_conn = ctx.state.db_pools[0]
+            .acquire()
+            .await
+            .expect("occupy read pool connection");
+
+        let (responder, response_rx) = tokio::sync::oneshot::channel();
+        ctx.state.shard_senders[0]
+            .send(ShardWriteOperation::Set {
+                key: "dedicated-writer".to_string(),
+                data: Bytes::from_static(b"value"),
+                expires_at: None,
+                responder,
+            })
+            .await
+            .expect("queue write");
+
+        let write_result = timeout(Duration::from_secs(1), response_rx)
+            .await
+            .expect("write should not be blocked by a busy read pool")
+            .expect("writer task dropped response channel");
+        assert!(write_result.is_ok(), "writer task should persist the value");
+
+        drop(read_conn);
+
+        let persisted = sqlx::query_scalar::<_, Vec<u8>>("SELECT data FROM blobs WHERE key = ?")
+            .bind("dedicated-writer")
+            .fetch_one(&ctx.state.db_pools[0])
+            .await
+            .expect("read back persisted value");
+        assert_eq!(persisted, b"value");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn del_completes_while_read_pool_connection_is_occupied() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let cfg = single_read_connection_cfg(&temp_dir, false);
+        let ctx = TestContext::from_cfg(temp_dir, cfg).await;
+
+        let frame = respond_with(&ctx, |state, stream| {
+            Box::pin(async move {
+                let mut stream = stream;
+                handle_set(
+                    &mut stream,
+                    &state,
+                    "delete-me".to_string(),
+                    Bytes::from_static(b"value"),
+                    None,
+                )
+                .await
+            })
+        })
+        .await;
+        assert_simple_string(frame, "OK");
+
+        let read_conn = ctx.state.db_pools[0]
+            .acquire()
+            .await
+            .expect("occupy read pool connection");
+
+        let frame = timeout(
+            Duration::from_secs(1),
+            respond_with(&ctx, |state, stream| {
+                Box::pin(async move {
+                    let mut stream = stream;
+                    handle_del_multiple(&mut stream, &state, vec!["delete-me".to_string()]).await
+                })
+            }),
+        )
+        .await
+        .expect("DEL should not block on the read pool");
+        assert_integer_response(frame, 1);
+
+        drop(read_conn);
+
+        let remaining = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM blobs WHERE key = ?")
+            .bind("delete-me")
+            .fetch_one(&ctx.state.db_pools[0])
+            .await
+            .expect("check deleted row");
+        assert_eq!(remaining, 0);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn hdel_completes_while_read_pool_connection_is_occupied() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let cfg = single_read_connection_cfg(&temp_dir, false);
+        let ctx = TestContext::from_cfg(temp_dir, cfg).await;
+
+        let frame = respond_with(&ctx, |state, stream| {
+            Box::pin(async move {
+                let mut stream = stream;
+                handle_hset(
+                    &mut stream,
+                    &state,
+                    "users".to_string(),
+                    "alice".to_string(),
+                    Bytes::from_static(b"value"),
+                )
+                .await
+            })
+        })
+        .await;
+        assert_integer_response(frame, 1);
+
+        let read_conn = ctx.state.db_pools[0]
+            .acquire()
+            .await
+            .expect("occupy read pool connection");
+
+        let frame = timeout(
+            Duration::from_secs(1),
+            respond_with(&ctx, |state, stream| {
+                Box::pin(async move {
+                    let mut stream = stream;
+                    handle_hdel(
+                        &mut stream,
+                        &state,
+                        "users".to_string(),
+                        "alice".to_string(),
+                    )
+                    .await
+                })
+            }),
+        )
+        .await
+        .expect("HDEL should not block on the read pool");
+        assert_integer_response(frame, 1);
+
+        drop(read_conn);
+
+        let remaining =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM blobs_users WHERE key = ?")
+                .bind("alice")
+                .fetch_one(&ctx.state.db_pools[0])
+                .await
+                .expect("check deleted hash field");
+        assert_eq!(remaining, 0);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn hset_and_hsetex_complete_while_read_pool_connection_is_occupied() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let cfg = single_read_connection_cfg(&temp_dir, false);
+        let ctx = TestContext::from_cfg(temp_dir, cfg).await;
+
+        let read_conn = ctx.state.db_pools[0]
+            .acquire()
+            .await
+            .expect("occupy read pool connection");
+
+        let frame = timeout(
+            Duration::from_secs(1),
+            respond_with(&ctx, |state, stream| {
+                Box::pin(async move {
+                    let mut stream = stream;
+                    handle_hset(
+                        &mut stream,
+                        &state,
+                        "users".to_string(),
+                        "alice".to_string(),
+                        Bytes::from_static(b"first"),
+                    )
+                    .await
+                })
+            }),
+        )
+        .await
+        .expect("HSET should not block on the read pool");
+        assert_integer_response(frame, 1);
+
+        let frame = timeout(
+            Duration::from_secs(1),
+            respond_with(&ctx, |state, stream| {
+                Box::pin(async move {
+                    let mut stream = stream;
+                    handle_hsetex(
+                        &mut stream,
+                        &state,
+                        "users".to_string(),
+                        true,
+                        false,
+                        None,
+                        vec![("bob".to_string(), Bytes::from_static(b"second"))],
+                    )
+                    .await
+                })
+            }),
+        )
+        .await
+        .expect("HSETEX should not block on the read pool");
+        assert_integer_response(frame, 1);
+
+        drop(read_conn);
+
+        let alice = sqlx::query_scalar::<_, Vec<u8>>("SELECT data FROM blobs_users WHERE key = ?")
+            .bind("alice")
+            .fetch_one(&ctx.state.db_pools[0])
+            .await
+            .expect("read back alice");
+        assert_eq!(alice, b"first");
+
+        let bob = sqlx::query_scalar::<_, Vec<u8>>("SELECT data FROM blobs_users WHERE key = ?")
+            .bind("bob")
+            .fetch_one(&ctx.state.db_pools[0])
+            .await
+            .expect("read back bob");
+        assert_eq!(bob, b"second");
 
         ctx.shutdown().await;
     }


### PR DESCRIPTION
Separate read and write SQLite pools per shard so writes can continue when read connections are saturated. Update the server paths and tests to verify write operations no longer block behind the read pool.

Closes #9 